### PR TITLE
feat: dynamic languages based on document

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
         "@sanity/icons": "^2.0.0",
         "@sanity/incompatible-plugin": "^1.0.4",
         "@sanity/ui": "^1.0.0",
+        "fast-deep-equal": "^3.1.3",
+        "lodash.get": "^4.4.2",
         "suspend-react": "^0.0.8"
       },
       "devDependencies": {
@@ -20,6 +22,7 @@
         "@sanity/pkg-utils": "^1.18.0",
         "@sanity/plugin-kit": "^2.1.17",
         "@sanity/semantic-release-preset": "^2.0.2",
+        "@types/lodash.get": "^4.4.7",
         "@types/styled-components": "^5.1.26",
         "@typescript-eslint/eslint-plugin": "^5.44.0",
         "@typescript-eslint/parser": "^5.44.0",
@@ -4825,6 +4828,15 @@
       "integrity": "sha512-5iJ3FBJBvQHQ8sFhEhJfjUP+G+LalhavTkYyrAYqz5MEJG+erSv0k9KJLb6q7++17Lafk1scaTIFXcMJlwK8Mw==",
       "dev": true
     },
+    "node_modules/@types/lodash.get": {
+      "version": "4.4.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.get/-/lodash.get-4.4.7.tgz",
+      "integrity": "sha512-af34Mj+KdDeuzsJBxc/XeTtOx0SZHZNLd+hdrn+PcKGQs0EG2TJTzQAOTCZTgDJCArahlCzLWSy8c2w59JRz7Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "*"
+      }
+    },
     "node_modules/@types/minimatch": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
@@ -8139,8 +8151,7 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-diff": {
       "version": "1.2.0",
@@ -10735,8 +10746,7 @@
     "node_modules/lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
-      "dev": true
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
     },
     "node_modules/lodash.isequal": {
       "version": "4.5.0",
@@ -22716,6 +22726,15 @@
       "integrity": "sha512-5iJ3FBJBvQHQ8sFhEhJfjUP+G+LalhavTkYyrAYqz5MEJG+erSv0k9KJLb6q7++17Lafk1scaTIFXcMJlwK8Mw==",
       "dev": true
     },
+    "@types/lodash.get": {
+      "version": "4.4.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.get/-/lodash.get-4.4.7.tgz",
+      "integrity": "sha512-af34Mj+KdDeuzsJBxc/XeTtOx0SZHZNLd+hdrn+PcKGQs0EG2TJTzQAOTCZTgDJCArahlCzLWSy8c2w59JRz7Q==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
     "@types/minimatch": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
@@ -25086,8 +25105,7 @@
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-diff": {
       "version": "1.2.0",
@@ -27041,8 +27059,7 @@
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
-      "dev": true
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
     },
     "lodash.isequal": {
       "version": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,8 @@
     "@sanity/icons": "^2.0.0",
     "@sanity/incompatible-plugin": "^1.0.4",
     "@sanity/ui": "^1.0.0",
+    "fast-deep-equal": "^3.1.3",
+    "lodash": "^4.17.21",
     "suspend-react": "^0.0.8"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@sanity/incompatible-plugin": "^1.0.4",
     "@sanity/ui": "^1.0.0",
     "fast-deep-equal": "^3.1.3",
-    "lodash": "^4.17.21",
+    "lodash.get": "^4.4.2",
     "suspend-react": "^0.0.8"
   },
   "devDependencies": {
@@ -60,6 +60,7 @@
     "@sanity/pkg-utils": "^1.18.0",
     "@sanity/plugin-kit": "^2.1.17",
     "@sanity/semantic-release-preset": "^2.0.2",
+    "@types/lodash.get": "^4.4.7",
     "@types/styled-components": "^5.1.26",
     "@typescript-eslint/eslint-plugin": "^5.44.0",
     "@typescript-eslint/parser": "^5.44.0",

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -15,4 +15,5 @@ export const preload = (fn: () => Promise<Language[]>) =>
 export const clear = () => suspend.clear([version, namespace])
 
 // https://github.com/pmndrs/suspend-react#peeking-into-entries-outside-of-suspense
-export const peek = () => suspend.peek([version, namespace]) as Language[] | undefined
+export const peek = (selectedValue: Record<string, unknown>) =>
+  suspend.peek([version, namespace, selectedValue]) as Language[] | undefined

--- a/src/components/InternationalizedArray.tsx
+++ b/src/components/InternationalizedArray.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useEffect, useMemo} from 'react'
+import React, {useCallback, useDeferredValue, useEffect, useMemo} from 'react'
 import {
   insert,
   set,
@@ -32,7 +32,11 @@ export default function InternationalizedArray(props: InternationalizedArrayProp
   const {options} = schemaType
   const toast = useToast()
   const {value: document} = useFormBuilder()
-  const selectedValue = getSelectedValue(options.select, document)
+  const deferredDocument = useDeferredValue(document)
+  const selectedValue = useMemo(
+    () => getSelectedValue(options.select, deferredDocument),
+    [options.select, deferredDocument]
+  )
 
   const {apiVersion} = options
   const client = useClient({apiVersion})

--- a/src/components/InternationalizedArray.tsx
+++ b/src/components/InternationalizedArray.tsx
@@ -1,4 +1,4 @@
-import React, {Fragment, useCallback, useEffect, useMemo} from 'react'
+import React, {useCallback, useEffect, useMemo} from 'react'
 import {
   insert,
   set,
@@ -7,10 +7,16 @@ import {
   ArrayOfObjectsItem,
   ArrayOfObjectsInputProps,
   useClient,
+  useFormBuilder,
+  SchemaType,
+  ObjectFieldType,
+  Reference,
 } from 'sanity'
 import {Button, Grid, Stack, useToast} from '@sanity/ui'
 import {AddIcon} from '@sanity/icons'
 import {suspend} from 'suspend-react'
+import {get} from 'lodash'
+import equal from 'fast-deep-equal'
 
 import type {Value, ArraySchemaWithLanguageOptions} from '../types'
 import Feedback from './Feedback'
@@ -23,23 +29,54 @@ export type InternationalizedArrayProps = ArrayOfObjectsInputProps<
   ArraySchemaWithLanguageOptions
 >
 
+const isReferenceArray = (schemaType: ObjectFieldType<SchemaType>) => {
+  return (
+    schemaType.type?.type?.name === 'array' &&
+    'of' in schemaType?.type &&
+    schemaType.type?.of.some((item) => item.type?.name === 'reference')
+  )
+}
+
 export default function InternationalizedArray(props: InternationalizedArrayProps) {
   const {members, value, schemaType, onChange} = props
   const readOnly = typeof schemaType.readOnly === 'boolean' ? schemaType.readOnly : false
   const {options} = schemaType
   const toast = useToast()
+  const {schemaType: documentSchemaType, value: document} = useFormBuilder()
+
+  const selection: Record<string, string> = options.select || {}
+  const targetKeys = Object.keys(selection)
+  const selectedValue = targetKeys.reduce<Record<string, unknown>>((acc, key) => {
+    // Find the field the value belongs to
+    const typeWithFields = 'fields' in documentSchemaType ? documentSchemaType : null
+    const targetFieldName = selection[key]
+    const valueField = typeWithFields?.fields?.find((f) => f.name === targetFieldName)
+
+    if (valueField?.type && isReferenceArray(valueField?.type)) {
+      // Filter out empty values from a reference array.
+      // Prevents refetching languages when no reference is (yet) selected.
+      acc[key] = (get(document, selection[key]) as Reference[])?.filter((item) => item._ref)
+    } else {
+      acc[key] = get(document, selection[key])
+    }
+    return acc
+  }, {})
 
   const {apiVersion} = options
   const client = useClient({apiVersion})
   const languages = Array.isArray(options.languages)
     ? options.languages
-    : // eslint-disable-next-line require-await
-      suspend(async () => {
-        if (typeof options.languages === 'function') {
-          return options.languages(client)
-        }
-        return options.languages
-      }, [version, namespace])
+    : suspend(
+        // eslint-disable-next-line require-await
+        async () => {
+          if (typeof options.languages === 'function') {
+            return options.languages(client, selectedValue)
+          }
+          return options.languages
+        },
+        [version, namespace, selectedValue],
+        {equal}
+      )
 
   const handleAddLanguage = useCallback(
     (languageId?: string) => {

--- a/src/components/Preload.tsx
+++ b/src/components/Preload.tsx
@@ -10,7 +10,7 @@ export default memo(function Preload(
   if (!Array.isArray(peek())) {
     // eslint-disable-next-line require-await
     preload(async () =>
-      Array.isArray(props.languages) ? props.languages : props.languages(client)
+      Array.isArray(props.languages) ? props.languages : props.languages(client, {})
     )
   }
 

--- a/src/components/Preload.tsx
+++ b/src/components/Preload.tsx
@@ -7,7 +7,7 @@ export default memo(function Preload(
   props: Required<Pick<PluginConfig, 'apiVersion' | 'languages'>>
 ) {
   const client = useClient({apiVersion: props.apiVersion})
-  if (!Array.isArray(peek())) {
+  if (!Array.isArray(peek({}))) {
     // eslint-disable-next-line require-await
     preload(async () =>
       Array.isArray(props.languages) ? props.languages : props.languages(client, {})

--- a/src/components/getSelectedValue.ts
+++ b/src/components/getSelectedValue.ts
@@ -13,12 +13,17 @@ export const getSelectedValue = (
   }
 
   const selection: Record<string, string> = select || {}
-  const targetKeys = Object.keys(selection)
-  const selectedValue = targetKeys.reduce<Record<string, unknown>>((acc, key) => {
-    acc[key] = get(document, selection[key])
-
-    return acc
-  }, {})
+  const selectedValue: Record<string, unknown> = {}
+  for (const [key, path] of Object.entries(selection)) {
+    let value = get(document, path)
+    if (Array.isArray(value)) {
+      // If there are references in the array, ensure they have `_ref` set, otherwise they are considered empty and can safely be ignored
+      value = value.filter((item) =>
+        typeof item === 'object' ? item?._type === 'reference' && '_ref' in item : true
+      )
+    }
+    selectedValue[key] = value
+  }
 
   return selectedValue
 }

--- a/src/components/getSelectedValue.ts
+++ b/src/components/getSelectedValue.ts
@@ -1,0 +1,24 @@
+import {get} from 'lodash'
+
+export const getSelectedValue = (
+  select: Record<string, string> | undefined,
+  document:
+    | {
+        [x: string]: unknown
+      }
+    | undefined
+): Record<string, unknown> => {
+  if (!select || !document) {
+    return {}
+  }
+
+  const selection: Record<string, string> = select || {}
+  const targetKeys = Object.keys(selection)
+  const selectedValue = targetKeys.reduce<Record<string, unknown>>((acc, key) => {
+    acc[key] = get(document, selection[key])
+
+    return acc
+  }, {})
+
+  return selectedValue
+}

--- a/src/plugin.tsx
+++ b/src/plugin.tsx
@@ -11,7 +11,7 @@ const CONFIG_DEFAULT: PluginConfig = {
 }
 
 export const internationalizedArray = definePlugin<PluginConfig>((config = CONFIG_DEFAULT) => {
-  const {apiVersion = '2022-11-27', languages, fieldTypes} = {...CONFIG_DEFAULT, ...config}
+  const {apiVersion = '2022-11-27', select, languages, fieldTypes} = {...CONFIG_DEFAULT, ...config}
 
   return {
     name: 'sanity-plugin-internationalized-array',
@@ -30,7 +30,7 @@ export const internationalizedArray = definePlugin<PluginConfig>((config = CONFI
         },
     schema: {
       types: [
-        ...fieldTypes.map((type) => array({type, apiVersion, languages})),
+        ...fieldTypes.map((type) => array({type, apiVersion, select, languages})),
         ...fieldTypes.map((type) => object({type})),
       ],
     },

--- a/src/schema/array.ts
+++ b/src/schema/array.ts
@@ -1,19 +1,20 @@
 /* eslint-disable no-nested-ternary */
-import {defineField, type FieldDefinition, type Rule, type SanityClient} from 'sanity'
+import {defineField, type FieldDefinition, type Rule} from 'sanity'
 import {peek} from '../cache'
 
 import {createFieldName} from '../components/createFieldName'
 import InternationalizedArray from '../components/InternationalizedArray'
-import {Language, Value} from '../types'
+import {Language, LanguageCallback, Value} from '../types'
 
 type ArrayFactoryConfig = {
   apiVersion: string
-  languages: Language[] | ((client: SanityClient) => Promise<Language[]>)
+  select?: Record<string, string>
+  languages: Language[] | LanguageCallback
   type: string | FieldDefinition
 }
 
 export default (config: ArrayFactoryConfig): FieldDefinition<'array'> => {
-  const {apiVersion, languages, type} = config
+  const {apiVersion, select, languages, type} = config
   const typeName = typeof type === `string` ? type : type.name
   const arrayName = createFieldName(typeName)
   const objectName = createFieldName(typeName, true)
@@ -27,7 +28,7 @@ export default (config: ArrayFactoryConfig): FieldDefinition<'array'> => {
     components: {
       input: InternationalizedArray,
     },
-    options: {apiVersion, languages},
+    options: {apiVersion, select, languages},
     // TODO: Resolve this typing issue with the inner object
     // @ts-ignore
     of: [

--- a/src/schema/array.ts
+++ b/src/schema/array.ts
@@ -3,6 +3,7 @@ import {defineField, type FieldDefinition, type Rule} from 'sanity'
 import {peek} from '../cache'
 
 import {createFieldName} from '../components/createFieldName'
+import {getSelectedValue} from '../components/getSelectedValue'
 import InternationalizedArray from '../components/InternationalizedArray'
 import {Language, LanguageCallback, Value} from '../types'
 
@@ -44,12 +45,13 @@ export default (config: ArrayFactoryConfig): FieldDefinition<'array'> => {
           return true
         }
 
+        const selectedValue = getSelectedValue(select, context.document)
         const client = context.getClient({apiVersion})
         const contextLanguages: Language[] = Array.isArray(context?.type?.options?.languages)
           ? context!.type!.options.languages
-          : Array.isArray(peek())
-          ? peek()
-          : await context?.type?.options.languages(client)
+          : Array.isArray(peek(selectedValue))
+          ? peek(selectedValue)
+          : await context?.type?.options.languages(client, selectedValue)
 
         if (value && value.length > contextLanguages.length) {
           return `Cannot be more than ${

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type {Rule, ArraySchemaType, RuleTypeConstraint, SanityClient} from 'sanity'
+import type {Rule, ArraySchemaType, RuleTypeConstraint, SanityClient, FieldDefinition} from 'sanity'
 
 export type Language = {
   id: Intl.UnicodeBCP47LocaleIdentifier
@@ -81,7 +81,7 @@ export type PluginConfig = {
    * }
    * ```
    */
-  fieldTypes: (string | RuleTypeConstraint)[]
+  fieldTypes: (string | RuleTypeConstraint | FieldDefinition)[]
 }
 
 export type ArraySchemaWithLanguageOptions = ArraySchemaType & {

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,12 +24,30 @@ export type Value = {
   value?: string
 }
 
+export type LanguageCallback = (
+  client: SanityClient,
+  selectedValue: Record<string, unknown>
+) => Promise<Language[]>
+
 export type PluginConfig = {
   /**
    * https://www.sanity.io/docs/api-versioning
    * @defaultValue '2022-11-27'
    */
   apiVersion?: string
+  /**
+   * Specify fields that should be available in the language callback:
+   * ```tsx
+   * {
+   *   select: {
+   *     markets: 'markets'
+   *   },
+   *   languages: (client, {markets}) =>
+   *     query.fetch(groq`*[_type == "language" && market in $markets]{id,title}`, {markets})
+   * }
+   * ```
+   */
+  select?: Record<string, string>
   /**
    * You can give it an array of language definitions:
    * ```tsx
@@ -57,7 +75,7 @@ export type PluginConfig = {
    * }
    * ```
    */
-  languages: Language[] | ((client: SanityClient) => Promise<Language[]>)
+  languages: Language[] | LanguageCallback
   /**
    * Can be a string matching core field types, as well as custom ones:
    * ```tsx
@@ -86,7 +104,8 @@ export type PluginConfig = {
 
 export type ArraySchemaWithLanguageOptions = ArraySchemaType & {
   options: {
-    languages: Language[] | ((client: SanityClient) => Promise<Language[]>)
+    select?: Record<string, string>
+    languages: Language[] | LanguageCallback
     apiVersion: string
   }
 }


### PR DESCRIPTION
Great work so far on this plugin @SimeonGriggs! Loading the languages asynchronously helps us a lot. In our case (as discussed with Tom in our [Sanity x Belsimpel trial](https://belsimpel.slack.com/archives/C04JSRMF26L)), we needed to load languages based on data in a document, so I want to take this opportunity to share this feature.

### Feature
I looked into multiple options for providing the document as parameter to the language callback, but the tricky thing is that the document changes a lot while editing. This made it so that the languages kept reloading and reloading. In the end, I wound up building a solution that's very similar to Sanity [list previews](https://www.sanity.io/docs/previews-list-views#770fd57a8f95). You can select your own fields in the document that should trigger a reload, and you get those fields directly in the language callback:

 ```tsx
{
	select: {
		markets: 'markets',
	},
	languages: (client, { markets }) =>
		client.fetch(groq`*[_type == "language" && market in $markets]{id,title}`, { markets }),
}
```

### Possible optimization
This works great already, but I have a small optimization in mind that I could use your help on. In our case, we want to load languages based on an array of references. The minor issue that we're seeing is that once you add an item to the array, it updates the document with an empty reference already before you choose a value: [UI](https://user-images.githubusercontent.com/1271226/214344864-46100bc5-28fe-4ebd-8efd-d8a54efe4ba8.png), [data](https://user-images.githubusercontent.com/1271226/214344900-0caf407d-e35d-4237-8287-bf089fe0be5f.png). Ideally we'd only want to reload languages if an actual reference value is filled in, do you know if there is a good way to fix this?

