### PR TITLE
fix: portable content integration and better error handling for member in error

### DIFF
--- a/src/components/InternationalizedArray.tsx
+++ b/src/components/InternationalizedArray.tsx
@@ -216,12 +216,9 @@ export default function InternationalizedArray(
             if (member.kind === 'item') {
               return (
                 <ArrayOfObjectsItem
+                  {...props}
                   key={member.key}
                   member={member}
-                  renderItem={props.renderItem}
-                  renderField={props.renderField}
-                  renderInput={props.renderInput}
-                  renderPreview={props.renderPreview}
                 />
               )
             }

--- a/src/components/InternationalizedArray.tsx
+++ b/src/components/InternationalizedArray.tsx
@@ -9,6 +9,7 @@ import {
   set,
   setIfMissing,
   useFormValue,
+  MemberItemError
 } from 'sanity'
 
 import {MAX_COLUMNS} from '../constants'
@@ -223,7 +224,7 @@ export default function InternationalizedArray(
               )
             }
 
-            return null
+            return <MemberItemError key={member.key} member={member} />
           })}
         </>
       ) : null}


### PR DESCRIPTION
After some try in order to fix issue #15 I found that forwarding all the props to ArrayOfObjectsItem solves the issue.

Also, following how array objects are handled in sanity, I've used `MemberItemError` instead of returning null in case of error