### PR TITLE
Always render the InternationalizedArrayProvider

### DIFF
--- a/src/plugin.tsx
+++ b/src/plugin.tsx
@@ -7,7 +7,6 @@ import {internationalizedArrayFieldAction} from './fieldActions'
 import array from './schema/array'
 import object from './schema/object'
 import {PluginConfig} from './types'
-import {flattenSchemaType} from './utils/flattenSchemaType'
 
 export const internationalizedArray = definePlugin<PluginConfig>((config) => {
   const pluginConfig = {...CONFIG_DEFAULT, ...config}
@@ -48,17 +47,6 @@ export const internationalizedArray = definePlugin<PluginConfig>((config) => {
           const isRootInput = props.id === 'root' && isObjectInputProps(props)
 
           if (!isRootInput) {
-            return props.renderDefault(props)
-          }
-
-          const flatFieldTypeNames = flattenSchemaType(props.schemaType).map(
-            (field) => field.type.name
-          )
-          const hasInternationalizedArray = flatFieldTypeNames.some((name) =>
-            name.startsWith('internationalizedArray')
-          )
-
-          if (!hasInternationalizedArray) {
             return props.renderDefault(props)
           }
 


### PR DESCRIPTION
This makes sure you can use internationalizedArrayString inside of nested objects without breaking things. The perf damage seems reasonable.

Fixes #37 

cc @appfr3d