### PR TITLE
feat: transform patch option

### DIFF
--- a/src/components/InternationalizedArray.tsx
+++ b/src/components/InternationalizedArray.tsx
@@ -40,6 +40,7 @@ export default function InternationalizedArray(
     defaultLanguages,
     buttonAddAll,
     buttonLocations,
+    addLanguagePatchTransform,
   } = useInternationalizedArrayContext()
 
   // Support updating the UI if languageFilter is installed
@@ -96,7 +97,11 @@ export default function InternationalizedArray(
         value,
       })
 
-      onChange([setIfMissing([]), ...patches])
+      const finalPatches = addLanguagePatchTransform
+        ? patches.map((patch) => addLanguagePatchTransform(patch, value))
+        : patches
+
+      onChange([setIfMissing([]), ...finalPatches])
     },
     [filteredLanguages, languages, onChange, schemaType, value]
   )

--- a/src/components/InternationalizedArrayContext.tsx
+++ b/src/components/InternationalizedArrayContext.tsx
@@ -14,7 +14,7 @@ import {getSelectedValue} from './getSelectedValue'
 // This provider makes the plugin config available to all components in the document form
 // But with languages resolved and filtered languages updated base on @sanity/language-filter
 
-type InternationalizedArrayContextProps = Required<PluginConfig> & {
+export type InternationalizedArrayContextProps = Required<PluginConfig> & {
   languages: Language[]
   filteredLanguages: Language[]
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,4 +10,5 @@ export const CONFIG_DEFAULT: Required<PluginConfig> = {
   apiVersion: '2022-11-27',
   buttonLocations: ['field'],
   buttonAddAll: true,
+  addLanguagePatchTransform: (patch) => patch,
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 import type {
   FieldDefinition,
+  FormInsertPatch,
   Rule,
   RuleTypeConstraint,
   SanityClient,
@@ -124,4 +125,12 @@ export type PluginConfig = {
    * @defaultValue true
    * */
   buttonAddAll?: boolean
+  /**
+   * Can be used to transform the add language patch
+   * ie to copy existing content from other languages automatically
+   */
+  addLanguagePatchTransform?: (
+    patch: FormInsertPatch,
+    value: unknown
+  ) => FormInsertPatch
 }


### PR DESCRIPTION
This would allow a user to override the add language patches before they get applied. This can be useful for copying default language content if this functionality is desired.