### PR TITLE
Address wierd behaviour in React Strict Mode

### DIFF
--- a/src/components/InternationalizedArray.tsx
+++ b/src/components/InternationalizedArray.tsx
@@ -1,7 +1,7 @@
 import {AddIcon} from '@sanity/icons'
 import {useLanguageFilterStudioContext} from '@sanity/language-filter'
 import {Button, Card, Stack, Text, useToast} from '@sanity/ui'
-import React, {useCallback, useEffect, useMemo, useState} from 'react'
+import React, {useCallback, useEffect, useMemo, useRef} from 'react'
 import {
   ArrayOfObjectsInputProps,
   ArrayOfObjectsItem,
@@ -103,14 +103,12 @@ export default function InternationalizedArray(
 
   // Create default fields if the document is not yet created
   const documentCreatedAt = useFormValue(['_createdAt'])
-  const [hasAddedDefaultLanguages, setHasAddedDefaultLanguages] = useState(
-    Boolean(documentCreatedAt)
-  )
+  const hasAddedDefaultLanguages = useRef(Boolean(documentCreatedAt))
 
   // Write default languages
   useEffect(() => {
     const shouldAddDefaultLanguages =
-      !hasAddedDefaultLanguages &&
+      !hasAddedDefaultLanguages.current &&
       !value &&
       !documentCreatedAt &&
       Array.isArray(defaultLanguages) &&
@@ -118,15 +116,14 @@ export default function InternationalizedArray(
 
     if (shouldAddDefaultLanguages) {
       handleAddLanguage(defaultLanguages)
-      setHasAddedDefaultLanguages(true)
     }
-  }, [
-    defaultLanguages,
-    documentCreatedAt,
-    handleAddLanguage,
-    hasAddedDefaultLanguages,
-    value,
-  ])
+
+    return () => {
+      if (shouldAddDefaultLanguages) {
+        hasAddedDefaultLanguages.current = true
+      }
+    }
+  }, [defaultLanguages, documentCreatedAt, handleAddLanguage, value])
 
   // TODO: This is reordering and re-setting the whole array, it could be surgical
   const handleRestoreOrder = useCallback(() => {

--- a/src/components/InternationalizedArray.tsx
+++ b/src/components/InternationalizedArray.tsx
@@ -109,18 +109,14 @@ export default function InternationalizedArray(
 
   // Write default languages
   useEffect(() => {
-    if (
-      // Hasn't already added default languages
-      // (This prevents the document being recreated when deleted)
+    const shouldAddDefaultLanguages =
       !hasAddedDefaultLanguages &&
-      // This array field is empty
       !value &&
-      // Document form is in "not yet created" state
       !documentCreatedAt &&
-      // Plugin config included default languages
       Array.isArray(defaultLanguages) &&
       defaultLanguages.length > 0
-    ) {
+
+    if (shouldAddDefaultLanguages) {
       handleAddLanguage(defaultLanguages)
       setHasAddedDefaultLanguages(true)
     }

--- a/src/components/InternationalizedArray.tsx
+++ b/src/components/InternationalizedArray.tsx
@@ -119,7 +119,7 @@ export default function InternationalizedArray(
       !documentCreatedAt &&
       // Plugin config included default languages
       Array.isArray(defaultLanguages) &&
-      defaultLanguages?.length > 0
+      defaultLanguages.length > 0
     ) {
       handleAddLanguage(defaultLanguages)
       setHasAddedDefaultLanguages(true)

--- a/src/components/InternationalizedArray.tsx
+++ b/src/components/InternationalizedArray.tsx
@@ -118,7 +118,7 @@ export default function InternationalizedArray(
       // Document form is in "not yet created" state
       !documentCreatedAt &&
       // Plugin config included default languages
-      defaultLanguages &&
+      Array.isArray(defaultLanguages) &&
       defaultLanguages?.length > 0
     ) {
       handleAddLanguage(defaultLanguages)


### PR DESCRIPTION
Fixes #47 

The issue is caused by running the Studio in [React Strict Mode](https://react.dev/reference/react/StrictMode). The area of interest is the fact that [effects run twice in development mode](https://react.dev/reference/react/StrictMode#fixing-bugs-found-by-re-running-effects-in-development). When Strict Mode is on, React will also run one extra setup+cleanup cycle in development for every Effect.