### PR TITLE
fix: resolve markdown field rendering issue

### DIFF
--- a/src/components/InternationalizedField.tsx
+++ b/src/components/InternationalizedField.tsx
@@ -1,29 +1,49 @@
-import type {FieldProps} from 'sanity'
+import type {ReactNode} from 'react'
+import {type FieldProps} from 'sanity'
 
-export default function InternationalizedField(props: FieldProps) {
+import {useInternationalizedArrayContext} from './InternationalizedArrayContext'
+
+export default function InternationalizedField(props: FieldProps): ReactNode {
+  const {languages} = useInternationalizedArrayContext()
+
+  // hide the title?
+  type LanguageKey = {_key: string}
+  const languageId: LanguageKey = props.path.slice(0, -1)[1] as LanguageKey
+  const hasValidLanguageId: boolean = languageId
+    ? languages.find((l) => l.id === languageId?._key) !== undefined
+    : false
+  const hideTitle = props.title?.toLowerCase() === 'value' && hasValidLanguageId
+  const customProps: FieldProps = {
+    ...props,
+    title: hideTitle ? '' : props.title,
+  }
+
+  if (!customProps.schemaType.name.startsWith('internationalizedArray')) {
+    return customProps.renderDefault(customProps)
+  }
+
   // Show reference field selector if there's a value
-  if (props.schemaType.name === 'reference' && props.value) {
-    return props.renderDefault({
-      ...props,
+  if (customProps.schemaType.name === 'reference' && customProps.value) {
+    return customProps.renderDefault({
+      ...customProps,
       title: '',
-      level: 0,
+      level: 0, // Reset the level to avoid nested styling
     })
   }
 
   // For basic field types, we can use children to keep the simple input
   if (
-    props.schemaType.name === 'string' ||
-    props.schemaType.name === 'number' ||
-    props.schemaType.name === 'text'
+    customProps.schemaType.name === 'string' ||
+    customProps.schemaType.name === 'number' ||
+    customProps.schemaType.name === 'text'
   ) {
-    return props.children
+    return customProps.children
   }
 
   // For complex fields (like markdown), we need to use renderDefault
   // to get all the field's functionality
-  return props.renderDefault({
-    ...props,
-    title: '', // Remove the title since we handle that in the wrapper
+  return customProps.renderDefault({
+    ...customProps,
     level: 0, // Reset the level to avoid nested styling
   })
 }

--- a/src/components/InternationalizedField.tsx
+++ b/src/components/InternationalizedField.tsx
@@ -7,6 +7,7 @@ import {useInternationalizedArrayContext} from './InternationalizedArrayContext'
 export default function InternationalizedField(props: FieldProps): ReactNode {
   const {languages} = useInternationalizedArrayContext()
 
+  // hide titles for 'value' fields within valid language entries
   const customProps = useMemo(() => {
     const pathSegment = props.path.slice(0, -1)[1]
     const languageId =

--- a/src/components/InternationalizedField.tsx
+++ b/src/components/InternationalizedField.tsx
@@ -10,5 +10,20 @@ export default function InternationalizedField(props: FieldProps) {
     })
   }
 
-  return props.children
+  // For basic field types, we can use children to keep the simple input
+  if (
+    props.schemaType.name === 'string' ||
+    props.schemaType.name === 'number' ||
+    props.schemaType.name === 'text'
+  ) {
+    return props.children
+  }
+
+  // For complex fields (like markdown), we need to use renderDefault
+  // to get all the field's functionality
+  return props.renderDefault({
+    ...props,
+    title: '', // Remove the title since we handle that in the wrapper
+    level: 0, // Reset the level to avoid nested styling
+  })
 }

--- a/src/components/InternationalizedInput.tsx
+++ b/src/components/InternationalizedInput.tsx
@@ -13,7 +13,7 @@ import {
   Tooltip,
 } from '@sanity/ui'
 import type React from 'react'
-import {useCallback, useMemo} from 'react'
+import {ReactNode, useCallback, useMemo} from 'react'
 import {type ObjectItemProps, Schema, useFormValue, useSchema} from 'sanity'
 import {set, unset} from 'sanity'
 
@@ -21,7 +21,7 @@ import {getLanguageDisplay} from '../utils/getLanguageDisplay'
 import {getToneFromValidation} from './getToneFromValidation'
 import {useInternationalizedArrayContext} from './InternationalizedArrayContext'
 
-type InternationalizedValue = {
+export type InternationalizedValue = {
   _type: string
   _key: string
   value: string
@@ -29,13 +29,10 @@ type InternationalizedValue = {
 
 export default function InternationalizedInput(
   props: ObjectItemProps<InternationalizedValue>
-) {
+): ReactNode {
   const parentValue = useFormValue(
     props.path.slice(0, -1)
   ) as InternationalizedValue[]
-
-  const schema: Schema = useSchema()
-  console.log({schema})
 
   const inlineProps = {
     ...props.inputProps,

--- a/src/components/InternationalizedInput.tsx
+++ b/src/components/InternationalizedInput.tsx
@@ -14,7 +14,7 @@ import {
 } from '@sanity/ui'
 import type React from 'react'
 import {ReactNode, useCallback, useMemo} from 'react'
-import {type ObjectItemProps, Schema, useFormValue, useSchema} from 'sanity'
+import {type ObjectItemProps, useFormValue} from 'sanity'
 import {set, unset} from 'sanity'
 
 import {getLanguageDisplay} from '../utils/getLanguageDisplay'
@@ -41,7 +41,7 @@ export default function InternationalizedInput(
       (m) => m.kind === 'field' && m.name === 'value'
     ),
     // This just overrides the type
-    // TODO: Remove this as it shouldn't be necessary?
+    // Remove this as it shouldn't be necessary?
     value: props.value as InternationalizedValue,
   }
 
@@ -61,7 +61,7 @@ export default function InternationalizedInput(
 
   // Changes the key of this item, ideally to a valid language
   const handleKeyChange = useCallback(
-    (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+    (event: React.MouseEvent<HTMLButtonElement, MouseEvent>): void => {
       const languageId = event?.currentTarget?.value
 
       if (
@@ -78,7 +78,7 @@ export default function InternationalizedInput(
   )
 
   // Removes this item from the array
-  const handleUnset = useCallback(() => {
+  const handleUnset = useCallback((): void => {
     onChange(unset())
   }, [onChange])
 

--- a/src/components/InternationalizedInput.tsx
+++ b/src/components/InternationalizedInput.tsx
@@ -14,7 +14,7 @@ import {
 } from '@sanity/ui'
 import type React from 'react'
 import {useCallback, useMemo} from 'react'
-import {type ObjectItemProps, useFormValue} from 'sanity'
+import {type ObjectItemProps, Schema, useFormValue, useSchema} from 'sanity'
 import {set, unset} from 'sanity'
 
 import {getLanguageDisplay} from '../utils/getLanguageDisplay'
@@ -33,6 +33,9 @@ export default function InternationalizedInput(
   const parentValue = useFormValue(
     props.path.slice(0, -1)
   ) as InternationalizedValue[]
+
+  const schema: Schema = useSchema()
+  console.log({schema})
 
   const inlineProps = {
     ...props.inputProps,

--- a/src/plugin.tsx
+++ b/src/plugin.tsx
@@ -45,17 +45,7 @@ export const internationalizedArray = definePlugin<PluginConfig>((config) => {
     // Wrap document editor with a language provider
     form: {
       components: {
-        field: (props) => {
-          // this is theonly condition that seems applicable in the props
-          if (
-            props.actions?.filter((action) =>
-              action.name.startsWith('internationalized')
-            )
-          ) {
-            return <InternationalizedField {...props} />
-          }
-          return props.renderDefault(props)
-        },
+        field: (props) => <InternationalizedField {...props} />,
 
         input: (props) => {
           const isRootInput = props.id === 'root' && isObjectInputProps(props)

--- a/src/plugin.tsx
+++ b/src/plugin.tsx
@@ -46,6 +46,7 @@ export const internationalizedArray = definePlugin<PluginConfig>((config) => {
     form: {
       components: {
         field: (props) => {
+          // this is theonly condition that seems applicable in the props
           if (
             props.actions?.filter((action) =>
               action.name.startsWith('internationalized')

--- a/src/plugin.tsx
+++ b/src/plugin.tsx
@@ -1,6 +1,7 @@
 import {definePlugin, isObjectInputProps} from 'sanity'
 
 import {InternationalizedArrayProvider} from './components/InternationalizedArrayContext'
+import InternationalizedField from './components/InternationalizedField'
 import Preload from './components/Preload'
 import {CONFIG_DEFAULT} from './constants'
 import {internationalizedArrayFieldAction} from './fieldActions'
@@ -44,6 +45,17 @@ export const internationalizedArray = definePlugin<PluginConfig>((config) => {
     // Wrap document editor with a language provider
     form: {
       components: {
+        field: (props) => {
+          if (
+            props.actions?.filter((action) =>
+              action.name.startsWith('internationalized')
+            )
+          ) {
+            return <InternationalizedField {...props} />
+          }
+          return props.renderDefault(props)
+        },
+
         input: (props) => {
           const isRootInput = props.id === 'root' && isObjectInputProps(props)
 

--- a/src/schema/object.ts
+++ b/src/schema/object.ts
@@ -1,7 +1,6 @@
 import {defineField, FieldDefinition} from 'sanity'
 
 import {createFieldName} from '../components/createFieldName'
-import InternationalizedField from '../components/InternationalizedField'
 import InternationalizedInput from '../components/InternationalizedInput'
 
 type ObjectFactoryConfig = {
@@ -12,10 +11,6 @@ export default (config: ObjectFactoryConfig): FieldDefinition<'object'> => {
   const {type} = config
   const typeName = typeof type === `string` ? type : type.name
   const objectName = createFieldName(typeName, true)
-
-  console.log('typeName:', typeName)
-  console.log('objectName:', objectName)
-  console.log('type:', type)
 
   return defineField({
     name: objectName,
@@ -30,9 +25,6 @@ export default (config: ObjectFactoryConfig): FieldDefinition<'object'> => {
         ...(typeof type === 'string' ? {type} : type),
         name: 'value',
         title: '',
-        // components: {
-        //   field: InternationalizedField,
-        // },
       }),
     ],
     preview: {

--- a/src/schema/object.ts
+++ b/src/schema/object.ts
@@ -24,7 +24,6 @@ export default (config: ObjectFactoryConfig): FieldDefinition<'object'> => {
       defineField({
         ...(typeof type === 'string' ? {type} : type),
         name: 'value',
-        title: '',
       }),
     ],
     preview: {

--- a/src/schema/object.ts
+++ b/src/schema/object.ts
@@ -13,6 +13,10 @@ export default (config: ObjectFactoryConfig): FieldDefinition<'object'> => {
   const typeName = typeof type === `string` ? type : type.name
   const objectName = createFieldName(typeName, true)
 
+  console.log('typeName:', typeName)
+  console.log('objectName:', objectName)
+  console.log('type:', type)
+
   return defineField({
     name: objectName,
     title: `Internationalized array ${type}`,
@@ -22,23 +26,14 @@ export default (config: ObjectFactoryConfig): FieldDefinition<'object'> => {
       item: InternationalizedInput,
     },
     fields: [
-      typeof type === `string`
-        ? // Define a simple field if all we have is the name as a string
-          defineField({
-            name: 'value',
-            type,
-            components: {
-              field: InternationalizedField,
-            },
-          })
-        : // Pass in the configured options, but overwrite the name
-          {
-            ...type,
-            name: 'value',
-            components: {
-              field: InternationalizedField,
-            },
-          },
+      defineField({
+        ...(typeof type === 'string' ? {type} : type),
+        name: 'value',
+        title: '',
+        // components: {
+        //   field: InternationalizedField,
+        // },
+      }),
     ],
     preview: {
       select: {


### PR DESCRIPTION
This PR fixes issue #49 by properly handling custom field types in InternationalizedField.

## Changes
- Fix custom field type rendering by properly handling props in InternationalizedField
- Ensure custom components are preserved while maintaining internationalization features
- Add proper type handling for field props

## Problem
The issue was caused by the InternationalizedField component not properly preserving custom field components while applying internationalization features. This was preventing custom field types like markdown from rendering correctly.

## Solution
This fix ensures that custom field types like markdown are rendered correctly while maintaining the plugin's internationalization functionality.